### PR TITLE
Fix archlinux debian sdk building doc

### DIFF
--- a/doc/setup.rst
+++ b/doc/setup.rst
@@ -242,7 +242,8 @@ On Arch Linux:
          qemu libvirt bridge-utils dnsmasq \
          virt-manager \
          debootstrap \
-         rust
+         rust \
+         debian-archive-keyring
 
 
 How to fetch the entire source tree?


### PR DESCRIPTION
A missing package from community repository 😃 
Fix debian debootstrap from archlinux building host.